### PR TITLE
More buffering and dropped writes.

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	"github.com/remind101/kinesis/kinesis"
+)
+
+func main() {
+	var (
+		streamName   = flag.String("stream", "", "Kinesis stream")
+		partitionKey = flag.String("partitionKey", "", "Partition key")
+	)
+	flag.Parse()
+
+	var total int
+	kinesis.Dropped = func(p []byte) {
+		log.Println(total)
+		log.Fatal("dropped writes")
+	}
+
+	ch := make(chan []byte)
+	go func() {
+		for range time.Tick(time.Millisecond * 10) {
+			ch <- make([]byte, 1024)
+		}
+	}()
+
+	w := kinesis.NewFastWriter(*streamName, *partitionKey)
+	for p := range ch {
+		_, err := w.Write(p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		total += len(p)
+	}
+}

--- a/kinesis/kinesis.go
+++ b/kinesis/kinesis.go
@@ -3,7 +3,12 @@
 package kinesis
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"math"
+	"os"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,6 +33,126 @@ const (
 	// RecordSizeLimit is the maximum allowed size per record.
 	RecordSizeLimit int = 1 * 1024 * 1024 // 1MB
 )
+
+// NewFastWriter returns an io.Writer that will ideally be able to flush to kinesis
+// as fast as possible. It will:
+//
+// 1. Buffer up to 4 MB if data in memory before flushing to Kinesis.
+// 2. If the buffer is not filled within 1 second, the data in the buffer will
+//    be flushed.
+// 4. If the calls to the Kinesis API become slow and fall behind, Writes will
+//    be dropped in 4mb chunks.
+func NewFastWriter(streamName, partitionKey string) *BufferedWriter {
+	return newFastWriter(NewDefaultWriter(streamName, partitionKey))
+}
+
+func newFastWriter(w io.Writer) *BufferedWriter {
+	// Allow up to 4 Writes to be queued, if the underlying io.Writer falls
+	// behind because of slow Writes, drop it.
+	dw := NewDropWriter(w, 4)
+
+	// Buffer 4mb in memory before flushing to Kinesis and periodically
+	// flush every second.
+	return NewBufferedWriter(dw, 4*1024*1024, time.Second)
+}
+
+type flushWriter interface {
+	io.Writer
+	Flush() error
+}
+
+// BufferedWriter is a wrapper around bufio.Writer that can periodically flush
+// the buffer instead of waiting for it to fill completely.
+type BufferedWriter struct {
+	w  flushWriter
+	mu sync.Mutex // Protects the underlying bufio.Writer, since we'll be flushing in a separate goroutine.
+	t  <-chan time.Time
+}
+
+// NewBufferedDefaultWriter returns a new io.Writer that buffers up to size
+// bytes in memory before flushing to the Kinesis. It will also periodically
+// flush the buffer if it is not full.
+func NewBufferedWriter(w io.Writer, size int, flush time.Duration) *BufferedWriter {
+	wr := &BufferedWriter{
+		w: bufio.NewWriterSize(w, size),
+		t: time.Tick(flush),
+	}
+	go wr.start()
+	return wr
+}
+
+// start receives on the ticker and flushes.
+func (w *BufferedWriter) start() {
+	for range w.t {
+		w.Flush()
+	}
+}
+
+// Write writes p to the underlying bufio.Writer.
+func (w *BufferedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Write(p)
+}
+
+// Flush flushe the underlying bufio.Writer.
+func (w *BufferedWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Flush()
+}
+
+// DropWriter is an io.Writer implementation that will drop writes when the
+// underlying io.Writer is too slow to process the write. It's generally
+// expected that you wrap this with a bufio.Writer.
+type DropWriter struct {
+	w       io.Writer
+	p       chan []byte
+	dropped func([]byte) // called when a Write is dropped.
+	err     error
+}
+
+// NewDropWriter returns a new DropWriter implementation that will drop writes.
+func NewDropWriter(w io.Writer, queue int) *DropWriter {
+	wr := &DropWriter{
+		w:       w,
+		dropped: Dropped,
+		p:       make(chan []byte, queue),
+	}
+	go wr.start()
+	return wr
+}
+
+// start starts writing the bytes in the queue.
+func (w *DropWriter) start() {
+	for p := range w.p {
+		if _, w.err = w.w.Write(p); w.err != nil {
+			return
+		}
+	}
+}
+
+// Write "writes" the bytes to the underlying channel. If the channel is full,
+// the packet is dropped.
+func (w *DropWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	select {
+	case w.p <- p:
+	default:
+		w.dropped(p)
+	}
+
+	return len(p), nil
+}
+
+// Dropped is the default function that is called when bytes are dropped by the
+// DropWriter.
+var Dropped = func(p []byte) {
+	fmt.Fprintf(os.Stderr, "dropping %d bytes", len(p))
+}
 
 // NewWriter returns a new Writer instance that writes to the given stream using
 // the given kinesis client.

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -24,7 +23,7 @@ func main() {
 
 	streamName := os.Args[1]
 
-	stream := bufio.NewWriter(kinesis.NewDefaultWriter(streamName, *partitionKey))
+	stream := newWriter(streamName, *partitionKey)
 
 	errCh := make(chan error, 1)
 	c := make(chan os.Signal, 1)
@@ -50,4 +49,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "err: %v", err)
 		os.Exit(1)
 	}
+}
+
+// newWriter returns an io.Writer that will ideally be able to flush to kinesis
+// as fast as possible.
+func newWriter(streamName, partitionKey string) *kinesis.BufferedWriter {
+	return kinesis.NewFastWriter(streamName, partitionKey)
 }


### PR DESCRIPTION
This does a few things:
1. It increases the in memory buffer (using bufio.Writer) from 4096 bytes to 4,194,304 bytes (4mb).
2. It inserts a `DroppedWriter` between the bufio.Writer and the underlying kinesis writer that will queue up to 4 writes (16mb) before dropping writes on the floor.
3. It will periodically flush the bufio.Writer so that data from slow producers will get flushed without having to wait for 4mb of data to queue up.

I benchmarked this up to about 100kb/s before it starts dropping packets on the floor. That should be more than enough throughput for our current use case.
